### PR TITLE
Adding failing reconnect spec. 

### DIFF
--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -1,0 +1,6 @@
+class Dog < ActiveRecord::Base
+  db_magic
+  belongs_to :user
+
+  default_scope :include => :user
+end

--- a/db/migrate/20120126190015_create_dogs.rb
+++ b/db/migrate/20120126190015_create_dogs.rb
@@ -1,0 +1,13 @@
+class CreateDogs < ActiveRecord::Migration
+  def self.up
+    create_table :dogs do |t|
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+
+  def self.down
+    drop_table :dogs
+  end
+end

--- a/spec/unit/active_record/reconnect_spec.rb
+++ b/spec/unit/active_record/reconnect_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+# ActiveRecord reconnecting is necessary in a pre-forking Rack server like Unicorn.
+#Connections need to be destroyed pre-fork, and reconnected post-fork
+describe "ActiveRecord reconnecting" do
+  context "querying on a model (LogRecord) that has default scope" do
+    before do
+      @id = Dog.create!(:user => User.create!).id
+    end
+
+    it "should not cause an exception after reconnecting" do
+      Dog.find_by_id(@id, :include => :user)
+
+      ActiveRecord::Base.connection_handler.clear_all_connections!
+      ActiveRecord::Base.connection_handler.verify_active_connections!
+      # The below line of code would make this test pass
+      # Dog.default_scoping.first.db_charmer_connection = ActiveRecord::Base.connection_handler.retrieve_connection(Dog)
+
+      Dog.find_by_id(@id, :include => :user)
+    end
+
+  end
+end


### PR DESCRIPTION
 Reconnecting may be necessary in forking servers like Unicorn.  This fork is in conjunction with the comment I made on issue #31 of db-charmer: https://github.com/kovyrin/db-charmer/issues/31#issuecomment-3663597.
